### PR TITLE
fix an env key

### DIFF
--- a/rails_relying_party_of_backend/lib/omniauth/strategies/my_op.rb
+++ b/rails_relying_party_of_backend/lib/omniauth/strategies/my_op.rb
@@ -44,7 +44,7 @@ module OmniAuth
         # raw_infoには、/userinfo エンドポイントから取得できる情報を入れる
         # 参考：userinfoエンドポイントのレスポンス
         #   {"sub"=>"1", "email"=>"foo@example.com"}
-        @raw_info ||= access_token.get("#{ENV['oidc_provider_host']}/oauth/userinfo").parsed
+        @raw_info ||= access_token.get("#{ENV['OIDC_PROVIDER_HOST']}/oauth/userinfo").parsed
       end
 
       def authorize_params


### PR DESCRIPTION
## 修正内容

環境変数のキーを修正

## 修正理由

修正箇所においてはおそらく小文字ではなく大文字でキーを指定するのが正しいと思われたため